### PR TITLE
switch to 2010 census tracts for geocoding

### DIFF
--- a/R/geocode_dm.R
+++ b/R/geocode_dm.R
@@ -196,7 +196,7 @@ dm.geocode_lat_long <- function(df,
                                 searchtype = "coordinates",
                                 returntype = "geographies",
                                 benchmark = "Public_AR_Current",
-                                vintage = "Current_Current",
+                                vintage = "Census2010_Current",
                                 query = "benchmark={benchmark}&vintage={vintage}&x={x}&y={y}") {
 
   lapply(1:nrow(df), function(i) {


### PR DESCRIPTION
@holmesjoli It seems like the issue was with the nber tract data coming from 2010 and our geocoding function using more recent tract data. There were 253 pre-ks in Harris County that did not get added to the Harris County subset hhsc_ccl (I think because of the tract matching issue), but all of those were added when I switched to 2010 census geocoding.

- Is this consistent with the plotting tracts? 
- If this looks good to you, will you make sure the code re-runs for the pre-k geocoding?
